### PR TITLE
Test Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tlsc
 tlss
 sslc
 tcpc
+tcps
 httppc
 httpc
 https

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIBS_TLS ?= -ltls `pkg-config --libs libssl`
 .PHONY: all test clean install
 .SUFFIXES: .c .o
 
-all: sockc tlsc tlss httppc httpc https ftpc
+all: sockc tlsc tlss httppc httpc https ftpc tcpc tcps
 
 # HTTP
 httpc.o: http_parser.h
@@ -19,6 +19,13 @@ httpc: httpc.o http_parser.o
 
 httppc: httppc.o http_parser.o
 	$(CC) $(LDFLAGS) -o $@ httppc.o http_parser.o
+
+# TCP
+tcpc: tcpc.o
+	$(CC) $(LDFLAGS) -o tcpc tcpc.o
+
+tcps: tcps.o
+	$(CC) $(LDFLAGS) -o tcps tcps.o
 
 # SSL/TLS
 tlsc: tlsc.o

--- a/test.sh
+++ b/test.sh
@@ -22,9 +22,8 @@ touch $tmpdir/tcps.log	# prevent ENOENT in until grep loop later
 ./tcps -d 127.0.0.1 0 /usr/bin/env 2>$tmpdir/tcps.log &
 
 # wait running server
-until grep -q '^listen: 127.0.0.1:' $tmpdir/tcps.log; do :; done
+until grep -q '^listen: 127.0.0.1:' $tmpdir/tcps.log; do printf . && sleep 1; done
 SERVER_PORT=$(sed -ne 's/^listen: 127.0.0.1://p' $tmpdir/tcps.log | head -n 1)
-
 # start client
 ./tcpc -d 127.0.0.1 $SERVER_PORT ./read6.sh $tmpdir/env.txt 2>$tmpdir/tcpc.log
 CLIENT_PORT=$(sed -ne 's/^listen: 127.0.0.1://p' $tmpdir/tcpc.log | head -n 1)

--- a/test.sh
+++ b/test.sh
@@ -5,12 +5,13 @@
 plan_tests 32
 
 # prepare
-file_grep() {
-	file=$1
-	regex=$2
-
-	grep -q "$regex" $file
-	ok $? "environment variable: \"$regex\""
+expect_env() {
+	file="$1"
+	key="$2"
+	expected="$3"
+	output="$(grep "^$key=" "$file")"
+	test "$key=$expected" = "$output"
+	ok $? "Expected $key to be $expected (found $output)"
 }
 
 tmpdir=$(mktemp -d tests_XXXXXX)
@@ -33,13 +34,13 @@ ok $? "plain connection server -> client"
 kill -9 %1
 
 # server side environment
-file_grep $tmpdir/env.txt "^TCPREMOTEIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEPORT=$CLIENT_PORT\$"
-file_grep $tmpdir/env.txt "^TCPLOCALIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPLOCALHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPLOCALPORT=$SERVER_PORT\$"
-file_grep $tmpdir/env.txt "^PROTO=TCP\$"
+expect_env $tmpdir/env.txt "TCPREMOTEIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPREMOTEHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPREMOTEPORT" "$CLIENT_PORT"
+expect_env $tmpdir/env.txt "TCPLOCALIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPLOCALHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPLOCALPORT" "$SERVER_PORT"
+expect_env $tmpdir/env.txt "PROTO" "TCP"
 
 #########################################################################
 # plain client to server communication					#
@@ -58,13 +59,13 @@ ok $? "plain connection client -> server"
 kill -9 %1
 
 # client side environment
-file_grep $tmpdir/env.txt "^TCPREMOTEIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEPORT=$SERVER_PORT\$"
-file_grep $tmpdir/env.txt "^TCPLOCALIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPLOCALHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPLOCALPORT=$CLIENT_PORT\$"
-file_grep $tmpdir/env.txt "^PROTO=TCP\$"
+expect_env $tmpdir/env.txt "TCPREMOTEIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPREMOTEHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPREMOTEPORT" "$SERVER_PORT"
+expect_env $tmpdir/env.txt "TCPLOCALIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPLOCALHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPLOCALPORT" "$CLIENT_PORT"
+expect_env $tmpdir/env.txt "PROTO" "TCP"
 
 #########################################################################
 # cert checks								#
@@ -96,13 +97,13 @@ ok $? "tls connection client -> server"
 kill -9 %1
 
 # client side environment
-file_grep $tmpdir/env.txt "^TCPREMOTEIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEPORT=$SERVER_PORT\$"
-file_grep $tmpdir/env.txt "^TCPLOCALIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPLOCALHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPLOCALPORT=$CLIENT_PORT\$"
-file_grep $tmpdir/env.txt "^PROTO=SSL\$"
+expect_env $tmpdir/env.txt "TCPREMOTEIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPREMOTEHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPREMOTEPORT" "$SERVER_PORT"
+expect_env $tmpdir/env.txt "TCPLOCALIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPLOCALHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPLOCALPORT" "$CLIENT_PORT"
+expect_env $tmpdir/env.txt "PROTO" "SSL"
 
 #########################################################################
 # encrypted server to client communication				#
@@ -126,13 +127,13 @@ ok $? "tls connection server -> client"
 kill -9 %1
 
 # server side environment
-file_grep $tmpdir/env.txt "^TCPREMOTEIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPREMOTEPORT=$CLIENT_PORT\$"
-file_grep $tmpdir/env.txt "^TCPLOCALIP=127.0.0.1\$"
-file_grep $tmpdir/env.txt "^TCPLOCALHOST=localhost\$"
-file_grep $tmpdir/env.txt "^TCPLOCALPORT=$SERVER_PORT\$"
-file_grep $tmpdir/env.txt "^PROTO=SSL\$"
+expect_env $tmpdir/env.txt "TCPREMOTEIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPREMOTEHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPREMOTEPORT" "$CLIENT_PORT"
+expect_env $tmpdir/env.txt "TCPLOCALIP" "127.0.0.1"
+expect_env $tmpdir/env.txt "TCPLOCALHOST" "localhost"
+expect_env $tmpdir/env.txt "TCPLOCALPORT" "$SERVER_PORT"
+expect_env $tmpdir/env.txt "PROTO" "SSL"
 
 # clean up
 rm -rf $tmpdir

--- a/test.sh
+++ b/test.sh
@@ -73,7 +73,10 @@ expect_env $tmpdir/env.txt "PROTO" "TCP"
 # cert checks								#
 #########################################################################
 
-# TODO: add a test here
+# These should have been created by 'make test'
+test -f ca.crt && test -f server.crt && test -f server.key && test -f client.crt && test -f client.key
+ok $? "Certificates and keys for running tests exist."
+# TODO: add more tests here
 #h=$(openssl x509 -outform der -in server.crt | sha256)
 #printf "SHA256:${h}\n"
 
@@ -85,7 +88,7 @@ expect_env $tmpdir/env.txt "PROTO" "TCP"
 	./read0.sh "$tmpdir/env.txt" 2>$tmpdir/tcps.log &
 
 # wait running server
-until grep -q '^listen: 127.0.0.1:' $tmpdir/tcps.log; do :; done
+until grep -q '^listen: 127.0.0.1:' $tmpdir/tcps.log; do printf . && sleep 1; done
 SERVER_PORT=$(sed -ne 's/^listen: 127.0.0.1://p' $tmpdir/tcps.log | head -n 1)
 
 ./tcpc -d 127.0.0.1 $SERVER_PORT			\

--- a/test.sh
+++ b/test.sh
@@ -42,6 +42,8 @@ expect_env $tmpdir/env.txt "TCPLOCALHOST" "localhost"
 expect_env $tmpdir/env.txt "TCPLOCALPORT" "$SERVER_PORT"
 expect_env $tmpdir/env.txt "PROTO" "TCP"
 
+rm "$tmpdir/env.txt"
+
 #########################################################################
 # plain client to server communication					#
 #########################################################################
@@ -105,6 +107,8 @@ expect_env $tmpdir/env.txt "TCPLOCALHOST" "localhost"
 expect_env $tmpdir/env.txt "TCPLOCALPORT" "$CLIENT_PORT"
 expect_env $tmpdir/env.txt "PROTO" "SSL"
 
+rm "$tmpdir/env.txt"
+
 #########################################################################
 # encrypted server to client communication				#
 #########################################################################
@@ -134,6 +138,8 @@ expect_env $tmpdir/env.txt "TCPLOCALIP" "127.0.0.1"
 expect_env $tmpdir/env.txt "TCPLOCALHOST" "localhost"
 expect_env $tmpdir/env.txt "TCPLOCALPORT" "$SERVER_PORT"
 expect_env $tmpdir/env.txt "PROTO" "SSL"
+
+rm "$tmpdir/env.txt"
 
 # clean up
 rm -rf $tmpdir


### PR DESCRIPTION
This adds some improvements for the tests, so it's easier to see what the problem is.

I had a few issues when trying to run this, which should be easier to discover with these changes to the tests
* tcps/tcpc weren't compiled (added them to the makefile)
* I didn't run them via `make test`, so was seeing a bunch of errors because the files weren't there
* the env files weren't getting removed between tests, so I was seeing a bunch of false-positives

Currently, the tests hang for me on the first `tlsc` test. It seems like something's not working. (maybe this is due to compiling with [`libretls`](https://pkgs.alpinelinux.org/package/v3.18/main/x86_64/libretls-dev), the "port of libtls from libressl to openssl", instead of libressl).